### PR TITLE
feat: codegen token limit and temperature override

### DIFF
--- a/prompt_pipeline/entrypoint.py
+++ b/prompt_pipeline/entrypoint.py
@@ -26,7 +26,41 @@ _ai_tutor = pathlib.Path(__file__).parent.parent / 'ai_tutor'
 sys.path.insert(0, str(_ai_tutor))
 
 from llm_client import LLMAPIClient  # noqa: E402
+from llm_configs import GeminiConfig, LLMConfig  # noqa: E402
 from entrypoint import get_model_key_from_env, get_config_class  # noqa: E402
+
+
+# Code generation needs higher token limits and deterministic output.
+# Tutoring (entrypoint.py) uses the config defaults (96 tokens, temp 0.2).
+CODEGEN_MAX_TOKENS = 4096
+CODEGEN_TEMPERATURE = 0
+
+
+def patch_config_for_codegen(config: LLMConfig) -> None:
+    """Override generation parameters for code generation.
+
+    Wraps config.format_request_data to set higher max_tokens and
+    temperature=0. Gemini uses ``generationConfig``; OpenAI-compatible
+    providers use top-level ``max_tokens`` / ``temperature``.
+    """
+    original = config.format_request_data
+
+    if isinstance(config, GeminiConfig):
+        def patched(question: str):
+            data = original(question)
+            data['generationConfig'] = {
+                'maxOutputTokens': CODEGEN_MAX_TOKENS,
+                'temperature': CODEGEN_TEMPERATURE,
+            }
+            return data
+    else:
+        def patched(question: str):
+            data = original(question)
+            data['max_tokens'] = CODEGEN_MAX_TOKENS
+            data['temperature'] = CODEGEN_TEMPERATURE
+            return data
+
+    config.format_request_data = patched
 
 
 # Python code detection patterns — prompts containing these are rejected.
@@ -99,6 +133,7 @@ def main() -> None:
     if model:
         config_args['model'] = model
     config = config_class(**config_args)
+    patch_config_for_codegen(config)
     client = LLMAPIClient(config)
 
     question = build_question(student_prompt)

--- a/tests/test_prompt_pipeline.py
+++ b/tests/test_prompt_pipeline.py
@@ -1,0 +1,202 @@
+# begin tests/test_prompt_pipeline.py
+"""Tests for prompt_pipeline code-generation config overrides."""
+import pathlib
+import sys
+
+import pytest
+
+
+# Adjust sys.path to import from project root
+test_folder = pathlib.Path(__file__).parent.resolve()
+project_folder = test_folder.parent.resolve()
+sys.path.insert(0, str(project_folder))
+
+from llm_configs import (
+    ClaudeConfig, GeminiConfig, GrokConfig, NvidiaNIMConfig, PerplexityConfig,
+)
+
+# prompt_pipeline.entrypoint imports from the tutor entrypoint via sys.path
+# manipulation that only works inside Docker.  Import the constants and
+# function we need by loading the file directly with importlib.
+import importlib.util
+
+_pp_spec = importlib.util.spec_from_file_location(
+    "prompt_pipeline_entrypoint",
+    project_folder / "prompt_pipeline" / "entrypoint.py",
+    submodule_search_locations=[],
+)
+_pp_mod = importlib.util.module_from_spec(_pp_spec)
+
+# Satisfy the "from entrypoint import ..." that prompt_pipeline/entrypoint.py
+# does at import time — point it at the tutor's entrypoint module.
+sys.modules['entrypoint'] = importlib.import_module('entrypoint')
+_pp_spec.loader.exec_module(_pp_mod)
+
+CODEGEN_MAX_TOKENS = _pp_mod.CODEGEN_MAX_TOKENS
+CODEGEN_TEMPERATURE = _pp_mod.CODEGEN_TEMPERATURE
+patch_config_for_codegen = _pp_mod.patch_config_for_codegen
+
+
+SAMPLE_API_KEY = "test_api_key_for_codegen"
+SAMPLE_QUESTION = "Write a function that computes factorial."
+
+
+# --- patch_config_for_codegen tests ---
+
+
+class TestPatchGemini:
+    """Gemini uses generationConfig with different key names."""
+
+    @pytest.fixture
+    def config(self):
+        c = GeminiConfig(api_key=SAMPLE_API_KEY)
+        patch_config_for_codegen(c)
+        return c
+
+    def test_has_generation_config(self, config):
+        data = config.format_request_data(SAMPLE_QUESTION)
+        assert 'generationConfig' in data
+
+    def test_max_output_tokens(self, config):
+        data = config.format_request_data(SAMPLE_QUESTION)
+        assert data['generationConfig']['maxOutputTokens'] == CODEGEN_MAX_TOKENS
+
+    def test_temperature_zero(self, config):
+        data = config.format_request_data(SAMPLE_QUESTION)
+        assert data['generationConfig']['temperature'] == CODEGEN_TEMPERATURE
+
+    def test_contents_preserved(self, config):
+        data = config.format_request_data(SAMPLE_QUESTION)
+        assert 'contents' in data
+        assert data['contents'][0]['parts'][0]['text'] == SAMPLE_QUESTION
+
+
+class TestPatchGrok:
+    """Grok already sets temperature=0; patch should override max_tokens."""
+
+    @pytest.fixture
+    def config(self):
+        c = GrokConfig(api_key=SAMPLE_API_KEY)
+        patch_config_for_codegen(c)
+        return c
+
+    def test_max_tokens(self, config):
+        data = config.format_request_data(SAMPLE_QUESTION)
+        assert data['max_tokens'] == CODEGEN_MAX_TOKENS
+
+    def test_temperature_zero(self, config):
+        data = config.format_request_data(SAMPLE_QUESTION)
+        assert data['temperature'] == CODEGEN_TEMPERATURE
+
+    def test_model_preserved(self, config):
+        data = config.format_request_data(SAMPLE_QUESTION)
+        assert data['model'] == 'grok-code-fast'
+
+
+class TestPatchNvidiaNIM:
+    """NVIDIA NIM inherits base defaults (96 tokens, temp 0.2)."""
+
+    @pytest.fixture
+    def config(self):
+        c = NvidiaNIMConfig(api_key=SAMPLE_API_KEY)
+        patch_config_for_codegen(c)
+        return c
+
+    def test_max_tokens_overridden(self, config):
+        data = config.format_request_data(SAMPLE_QUESTION)
+        assert data['max_tokens'] == CODEGEN_MAX_TOKENS
+
+    def test_temperature_overridden(self, config):
+        data = config.format_request_data(SAMPLE_QUESTION)
+        assert data['temperature'] == CODEGEN_TEMPERATURE
+
+
+class TestPatchClaude:
+    """Claude overrides max_tokens to 1024; patch should raise to CODEGEN_MAX_TOKENS."""
+
+    @pytest.fixture
+    def config(self):
+        c = ClaudeConfig(api_key=SAMPLE_API_KEY)
+        patch_config_for_codegen(c)
+        return c
+
+    def test_max_tokens_overridden(self, config):
+        data = config.format_request_data(SAMPLE_QUESTION)
+        assert data['max_tokens'] == CODEGEN_MAX_TOKENS
+
+    def test_temperature_overridden(self, config):
+        data = config.format_request_data(SAMPLE_QUESTION)
+        assert data['temperature'] == CODEGEN_TEMPERATURE
+
+
+class TestPatchPerplexity:
+    """Perplexity overrides max_tokens to 384; patch should raise to CODEGEN_MAX_TOKENS."""
+
+    @pytest.fixture
+    def config(self):
+        c = PerplexityConfig(api_key=SAMPLE_API_KEY)
+        patch_config_for_codegen(c)
+        return c
+
+    def test_max_tokens_overridden(self, config):
+        data = config.format_request_data(SAMPLE_QUESTION)
+        assert data['max_tokens'] == CODEGEN_MAX_TOKENS
+
+    def test_temperature_overridden(self, config):
+        data = config.format_request_data(SAMPLE_QUESTION)
+        assert data['temperature'] == CODEGEN_TEMPERATURE
+
+
+class TestUnpatchedDefaults:
+    """Verify that unpatched configs retain their original defaults."""
+
+    def test_base_max_tokens_96(self):
+        c = NvidiaNIMConfig(api_key=SAMPLE_API_KEY)
+        data = c.format_request_data(SAMPLE_QUESTION)
+        assert data['max_tokens'] == 96
+
+    def test_base_temperature_02(self):
+        c = NvidiaNIMConfig(api_key=SAMPLE_API_KEY)
+        data = c.format_request_data(SAMPLE_QUESTION)
+        assert data['temperature'] == 0.2
+
+    def test_gemini_no_generation_config(self):
+        c = GeminiConfig(api_key=SAMPLE_API_KEY)
+        data = c.format_request_data(SAMPLE_QUESTION)
+        assert 'generationConfig' not in data
+
+    def test_claude_max_tokens_1024(self):
+        c = ClaudeConfig(api_key=SAMPLE_API_KEY)
+        data = c.format_request_data(SAMPLE_QUESTION)
+        assert data['max_tokens'] == 1024
+
+    def test_perplexity_max_tokens_384(self):
+        c = PerplexityConfig(api_key=SAMPLE_API_KEY)
+        data = c.format_request_data(SAMPLE_QUESTION)
+        assert data['max_tokens'] == 384
+
+
+class TestPatchDoesNotMutateOtherInstances:
+    """Patching one config must not affect a separate instance."""
+
+    def test_two_gemini_instances(self):
+        patched = GeminiConfig(api_key=SAMPLE_API_KEY)
+        unpatched = GeminiConfig(api_key=SAMPLE_API_KEY)
+        patch_config_for_codegen(patched)
+
+        assert 'generationConfig' in patched.format_request_data(SAMPLE_QUESTION)
+        assert 'generationConfig' not in unpatched.format_request_data(SAMPLE_QUESTION)
+
+    def test_two_grok_instances(self):
+        patched = GrokConfig(api_key=SAMPLE_API_KEY)
+        unpatched = GrokConfig(api_key=SAMPLE_API_KEY)
+        patch_config_for_codegen(patched)
+
+        assert patched.format_request_data(SAMPLE_QUESTION)['max_tokens'] == CODEGEN_MAX_TOKENS
+        assert 'max_tokens' not in unpatched.format_request_data(SAMPLE_QUESTION)
+
+
+if __name__ == "__main__":
+    pytest.main(["--verbose", __file__])
+
+# end tests/test_prompt_pipeline.py


### PR DESCRIPTION
## Summary
- Raise `max_tokens` from provider defaults (96–1024) to 4096 for the code generation path (`prompt_pipeline/entrypoint.py`), preventing truncation of generated `exercise.py` on longer assignments
- Set `temperature=0` for deterministic code generation across all providers
- Tutoring path (`entrypoint.py`) defaults are unchanged — this only affects prompt-only assignment code generation

## Provider-specific handling
- **Gemini**: adds `generationConfig.maxOutputTokens` + `generationConfig.temperature` (Gemini uses different key names)
- **OpenAI-compatible** (Grok, Claude, NVIDIA NIM, Perplexity): overrides top-level `max_tokens` + `temperature`

## Test plan
- [x] 20 new tests in `tests/test_prompt_pipeline.py` covering all 5 providers
- [x] Verifies patched configs get codegen values
- [x] Verifies unpatched configs retain tutoring defaults
- [x] Verifies patching one instance does not affect other instances
- [x] Full suite: 231 passed (211 existing + 20 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)