### PR TITLE
feat: codegen token limit and temperature override

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -151,4 +151,59 @@ jobs:
         echo "feedback_${{ matrix.model }}=${{ steps.integration.outputs.feedback }}" >> $GITHUB_OUTPUT
         python3 -u -m pytest tests/integration.py
 
+  integration-tests-codegen:
+    needs: build
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - model: gemini-2.5-flash
+            secret: GOOGLE_API_KEY
+          - model: grok-code-fast
+            secret: XAI_API_KEY
+          - model: claude-sonnet-4-20250514
+            secret: CLAUDE_API_KEY
+          - model: google/gemma-2-9b-it
+            secret: NVIDIA_NIM_API_KEY
+          - model: sonar
+            secret: PERPLEXITY_API_KEY
+      fail-fast: false
+    steps:
+    - uses: actions/checkout@v6
+
+    - name: Install uv package manager
+      uses: astral-sh/setup-uv@v7
+      with:
+        version: "latest"
+        version-file: "pyproject.toml"
+        python-version: 3.11
+        enable-cache: true
+
+    - run: uv sync
+
+    - name: Generate exercise.py with ${{ matrix.model }}
+      env:
+        INPUT_PROMPT-FILE: tests/sample_prompt.txt
+        CONTAINER_OUTPUT: ${{ runner.temp }}/codegen_output
+        INPUT_CLAUDE_API_KEY: ${{ secrets.CLAUDE_API_KEY }}
+        INPUT_GEMINI-API-KEY: ${{ secrets.GOOGLE_API_KEY }}
+        INPUT_GROK-API-KEY: ${{ secrets.XAI_API_KEY }}
+        INPUT_NVIDIA-API-KEY: ${{ secrets.NVIDIA_NIM_API_KEY }}
+        INPUT_PERPLEXITY-API-KEY: ${{ secrets.PERPLEXITY_API_KEY }}
+        INPUT_MODEL: ${{ matrix.model }}
+      run: |
+        . .venv/bin/activate
+        python3 prompt_pipeline/entrypoint.py
+      timeout-minutes: 5
+
+    - name: Show generated exercise.py
+      run: cat ${{ runner.temp }}/codegen_output/exercise.py
+
+    - name: Verify generated code
+      env:
+        CONTAINER_OUTPUT: ${{ runner.temp }}/codegen_output
+      run: |
+        . .venv/bin/activate
+        python3 -u -m pytest tests/integration_codegen.py -v
+
 # end .github/workflows/build.yml

--- a/prompt_pipeline/entrypoint.py
+++ b/prompt_pipeline/entrypoint.py
@@ -22,8 +22,13 @@ logging.basicConfig(level=logging.INFO)
 # ai_tutor/ lives one level above prompt_pipeline/ inside the container:
 #   /app/ai_tutor/   ← llm_client.py, llm_configs.py, entrypoint.py
 #   /app/prompt_pipeline/  ← this file
-_ai_tutor = pathlib.Path(__file__).parent.parent / 'ai_tutor'
-sys.path.insert(0, str(_ai_tutor))
+# In CI / local dev, the modules live at the repo root instead.
+_project_root = pathlib.Path(__file__).parent.parent
+_ai_tutor = _project_root / 'ai_tutor'
+if _ai_tutor.is_dir():
+    sys.path.insert(0, str(_ai_tutor))
+else:
+    sys.path.insert(0, str(_project_root))
 
 from llm_client import LLMAPIClient  # noqa: E402
 from llm_configs import GeminiConfig, LLMConfig  # noqa: E402

--- a/prompt_pipeline/entrypoint.py
+++ b/prompt_pipeline/entrypoint.py
@@ -26,7 +26,41 @@ _ai_tutor = pathlib.Path(__file__).parent.parent / 'ai_tutor'
 sys.path.insert(0, str(_ai_tutor))
 
 from llm_client import LLMAPIClient  # noqa: E402
+from llm_configs import GeminiConfig, LLMConfig  # noqa: E402
 from entrypoint import get_model_key_from_env, get_config_class  # noqa: E402
+
+
+# Code generation needs higher token limits and deterministic output.
+# Tutoring (entrypoint.py) uses the config defaults (96 tokens, temp 0.2).
+CODEGEN_MAX_TOKENS = 4096
+CODEGEN_TEMPERATURE = 0
+
+
+def patch_config_for_codegen(config: LLMConfig) -> None:
+    """Override generation parameters for code generation.
+
+    Wraps config.format_request_data to set higher max_tokens and
+    temperature=0. Gemini uses ``generationConfig``; OpenAI-compatible
+    providers use top-level ``max_tokens`` / ``temperature``.
+    """
+    original = config.format_request_data
+
+    if isinstance(config, GeminiConfig):
+        def patched(question: str):
+            data = original(question)
+            data['generationConfig'] = {
+                'maxOutputTokens': CODEGEN_MAX_TOKENS,
+                'temperature': CODEGEN_TEMPERATURE,
+            }
+            return data
+    else:
+        def patched(question: str):
+            data = original(question)
+            data['max_tokens'] = CODEGEN_MAX_TOKENS
+            data['temperature'] = CODEGEN_TEMPERATURE
+            return data
+
+    config.format_request_data = patched
 
 
 # Python code detection patterns — prompts containing these are rejected.
@@ -99,6 +133,7 @@ def main() -> None:
     if model:
         config_args['model'] = model
     config = config_class(**config_args)
+    patch_config_for_codegen(config)
     client = LLMAPIClient(config)
 
     question = build_question(student_prompt)

--- a/tests/integration_codegen.py
+++ b/tests/integration_codegen.py
@@ -1,0 +1,93 @@
+# begin tests/integration_codegen.py
+"""Integration tests for the prompt pipeline (code generation).
+
+Run after prompt_pipeline/entrypoint.py has generated exercise.py.
+Verifies the output is valid Python containing the expected functions.
+"""
+import ast
+import logging
+import os
+import pathlib
+
+import pytest
+
+
+logging.basicConfig(level=logging.INFO)
+
+
+@pytest.fixture
+def exercise_path():
+    """Path to the generated exercise.py."""
+    output_dir = os.environ.get('CONTAINER_OUTPUT', '')
+    if not output_dir:
+        pytest.skip("CONTAINER_OUTPUT not set")
+    path = pathlib.Path(output_dir) / 'exercise.py'
+    if not path.exists():
+        pytest.fail(f"exercise.py not found at {path}")
+    return path
+
+
+@pytest.fixture
+def exercise_source(exercise_path):
+    """Raw source code of generated exercise.py."""
+    return exercise_path.read_text(encoding='utf-8')
+
+
+@pytest.fixture
+def exercise_ast(exercise_source):
+    """Parsed AST of generated exercise.py."""
+    try:
+        return ast.parse(exercise_source)
+    except SyntaxError as e:
+        pytest.fail(f"exercise.py has invalid syntax: {e}")
+
+
+def test_exercise_exists(exercise_path):
+    """exercise.py was written to disk."""
+    assert exercise_path.exists()
+
+
+def test_exercise_not_empty(exercise_source):
+    """exercise.py is not empty."""
+    assert len(exercise_source.strip()) > 0
+
+
+def test_exercise_valid_python(exercise_ast):
+    """exercise.py parses as valid Python."""
+    assert exercise_ast is not None
+
+
+def test_exercise_has_add_function(exercise_ast):
+    """exercise.py defines an `add` function."""
+    func_names = [
+        node.name for node in ast.walk(exercise_ast)
+        if isinstance(node, ast.FunctionDef)
+    ]
+    assert 'add' in func_names, (
+        f"Expected 'add' function, found: {func_names}"
+    )
+
+
+def test_exercise_has_multiply_function(exercise_ast):
+    """exercise.py defines a `multiply` function."""
+    func_names = [
+        node.name for node in ast.walk(exercise_ast)
+        if isinstance(node, ast.FunctionDef)
+    ]
+    assert 'multiply' in func_names, (
+        f"Expected 'multiply' function, found: {func_names}"
+    )
+
+
+def test_exercise_not_truncated(exercise_source):
+    """exercise.py is long enough to contain two function definitions."""
+    assert len(exercise_source) > 50, (
+        f"exercise.py suspiciously short ({len(exercise_source)} chars) "
+        "— may have been truncated by low max_tokens"
+    )
+
+
+if __name__ == "__main__":
+    pytest.main(["--verbose", __file__])
+
+# end tests/integration_codegen.py

--- a/tests/sample_prompt.txt
+++ b/tests/sample_prompt.txt
@@ -1,0 +1,2 @@
+Write a Python function called `add(a, b)` that takes two numbers as parameters and returns their sum.
+Also write a function called `multiply(a, b)` that takes two numbers and returns their product.

--- a/tests/test_prompt_pipeline.py
+++ b/tests/test_prompt_pipeline.py
@@ -1,0 +1,202 @@
+# begin tests/test_prompt_pipeline.py
+"""Tests for prompt_pipeline code-generation config overrides."""
+import pathlib
+import sys
+
+import pytest
+
+
+# Adjust sys.path to import from project root
+test_folder = pathlib.Path(__file__).parent.resolve()
+project_folder = test_folder.parent.resolve()
+sys.path.insert(0, str(project_folder))
+
+from llm_configs import (
+    ClaudeConfig, GeminiConfig, GrokConfig, NvidiaNIMConfig, PerplexityConfig,
+)
+
+# prompt_pipeline.entrypoint imports from the tutor entrypoint via sys.path
+# manipulation that only works inside Docker.  Import the constants and
+# function we need by loading the file directly with importlib.
+import importlib.util
+
+_pp_spec = importlib.util.spec_from_file_location(
+    "prompt_pipeline_entrypoint",
+    project_folder / "prompt_pipeline" / "entrypoint.py",
+    submodule_search_locations=[],
+)
+_pp_mod = importlib.util.module_from_spec(_pp_spec)
+
+# Satisfy the "from entrypoint import ..." that prompt_pipeline/entrypoint.py
+# does at import time — point it at the tutor's entrypoint module.
+sys.modules['entrypoint'] = importlib.import_module('entrypoint')
+_pp_spec.loader.exec_module(_pp_mod)
+
+CODEGEN_MAX_TOKENS = _pp_mod.CODEGEN_MAX_TOKENS
+CODEGEN_TEMPERATURE = _pp_mod.CODEGEN_TEMPERATURE
+patch_config_for_codegen = _pp_mod.patch_config_for_codegen
+
+
+SAMPLE_API_KEY = "test_api_key_for_codegen"
+SAMPLE_QUESTION = "Write a function that computes factorial."
+
+
+# --- patch_config_for_codegen tests ---
+
+
+class TestPatchGemini:
+    """Gemini uses generationConfig with different key names."""
+
+    @pytest.fixture
+    def config(self):
+        c = GeminiConfig(api_key=SAMPLE_API_KEY)
+        patch_config_for_codegen(c)
+        return c
+
+    def test_has_generation_config(self, config):
+        data = config.format_request_data(SAMPLE_QUESTION)
+        assert 'generationConfig' in data
+
+    def test_max_output_tokens(self, config):
+        data = config.format_request_data(SAMPLE_QUESTION)
+        assert data['generationConfig']['maxOutputTokens'] == CODEGEN_MAX_TOKENS
+
+    def test_temperature_zero(self, config):
+        data = config.format_request_data(SAMPLE_QUESTION)
+        assert data['generationConfig']['temperature'] == CODEGEN_TEMPERATURE
+
+    def test_contents_preserved(self, config):
+        data = config.format_request_data(SAMPLE_QUESTION)
+        assert 'contents' in data
+        assert data['contents'][0]['parts'][0]['text'] == SAMPLE_QUESTION
+
+
+class TestPatchGrok:
+    """Grok already sets temperature=0; patch should override max_tokens."""
+
+    @pytest.fixture
+    def config(self):
+        c = GrokConfig(api_key=SAMPLE_API_KEY)
+        patch_config_for_codegen(c)
+        return c
+
+    def test_max_tokens(self, config):
+        data = config.format_request_data(SAMPLE_QUESTION)
+        assert data['max_tokens'] == CODEGEN_MAX_TOKENS
+
+    def test_temperature_zero(self, config):
+        data = config.format_request_data(SAMPLE_QUESTION)
+        assert data['temperature'] == CODEGEN_TEMPERATURE
+
+    def test_model_preserved(self, config):
+        data = config.format_request_data(SAMPLE_QUESTION)
+        assert data['model'] == 'grok-code-fast'
+
+
+class TestPatchNvidiaNIM:
+    """NVIDIA NIM inherits base defaults (96 tokens, temp 0.2)."""
+
+    @pytest.fixture
+    def config(self):
+        c = NvidiaNIMConfig(api_key=SAMPLE_API_KEY)
+        patch_config_for_codegen(c)
+        return c
+
+    def test_max_tokens_overridden(self, config):
+        data = config.format_request_data(SAMPLE_QUESTION)
+        assert data['max_tokens'] == CODEGEN_MAX_TOKENS
+
+    def test_temperature_overridden(self, config):
+        data = config.format_request_data(SAMPLE_QUESTION)
+        assert data['temperature'] == CODEGEN_TEMPERATURE
+
+
+class TestPatchClaude:
+    """Claude overrides max_tokens to 1024; patch should raise to CODEGEN_MAX_TOKENS."""
+
+    @pytest.fixture
+    def config(self):
+        c = ClaudeConfig(api_key=SAMPLE_API_KEY)
+        patch_config_for_codegen(c)
+        return c
+
+    def test_max_tokens_overridden(self, config):
+        data = config.format_request_data(SAMPLE_QUESTION)
+        assert data['max_tokens'] == CODEGEN_MAX_TOKENS
+
+    def test_temperature_overridden(self, config):
+        data = config.format_request_data(SAMPLE_QUESTION)
+        assert data['temperature'] == CODEGEN_TEMPERATURE
+
+
+class TestPatchPerplexity:
+    """Perplexity overrides max_tokens to 384; patch should raise to CODEGEN_MAX_TOKENS."""
+
+    @pytest.fixture
+    def config(self):
+        c = PerplexityConfig(api_key=SAMPLE_API_KEY)
+        patch_config_for_codegen(c)
+        return c
+
+    def test_max_tokens_overridden(self, config):
+        data = config.format_request_data(SAMPLE_QUESTION)
+        assert data['max_tokens'] == CODEGEN_MAX_TOKENS
+
+    def test_temperature_overridden(self, config):
+        data = config.format_request_data(SAMPLE_QUESTION)
+        assert data['temperature'] == CODEGEN_TEMPERATURE
+
+
+class TestUnpatchedDefaults:
+    """Verify that unpatched configs retain their original defaults."""
+
+    def test_base_max_tokens_96(self):
+        c = NvidiaNIMConfig(api_key=SAMPLE_API_KEY)
+        data = c.format_request_data(SAMPLE_QUESTION)
+        assert data['max_tokens'] == 96
+
+    def test_base_temperature_02(self):
+        c = NvidiaNIMConfig(api_key=SAMPLE_API_KEY)
+        data = c.format_request_data(SAMPLE_QUESTION)
+        assert data['temperature'] == 0.2
+
+    def test_gemini_no_generation_config(self):
+        c = GeminiConfig(api_key=SAMPLE_API_KEY)
+        data = c.format_request_data(SAMPLE_QUESTION)
+        assert 'generationConfig' not in data
+
+    def test_claude_max_tokens_1024(self):
+        c = ClaudeConfig(api_key=SAMPLE_API_KEY)
+        data = c.format_request_data(SAMPLE_QUESTION)
+        assert data['max_tokens'] == 1024
+
+    def test_perplexity_max_tokens_384(self):
+        c = PerplexityConfig(api_key=SAMPLE_API_KEY)
+        data = c.format_request_data(SAMPLE_QUESTION)
+        assert data['max_tokens'] == 384
+
+
+class TestPatchDoesNotMutateOtherInstances:
+    """Patching one config must not affect a separate instance."""
+
+    def test_two_gemini_instances(self):
+        patched = GeminiConfig(api_key=SAMPLE_API_KEY)
+        unpatched = GeminiConfig(api_key=SAMPLE_API_KEY)
+        patch_config_for_codegen(patched)
+
+        assert 'generationConfig' in patched.format_request_data(SAMPLE_QUESTION)
+        assert 'generationConfig' not in unpatched.format_request_data(SAMPLE_QUESTION)
+
+    def test_two_grok_instances(self):
+        patched = GrokConfig(api_key=SAMPLE_API_KEY)
+        unpatched = GrokConfig(api_key=SAMPLE_API_KEY)
+        patch_config_for_codegen(patched)
+
+        assert patched.format_request_data(SAMPLE_QUESTION)['max_tokens'] == CODEGEN_MAX_TOKENS
+        assert 'max_tokens' not in unpatched.format_request_data(SAMPLE_QUESTION)
+
+
+if __name__ == "__main__":
+    pytest.main(["--verbose", __file__])
+
+# end tests/test_prompt_pipeline.py


### PR DESCRIPTION
## Summary
- Raise `max_tokens` from provider defaults (96–1024) to 4096 for the code generation path (`prompt_pipeline/entrypoint.py`), preventing truncation of generated `exercise.py` on longer assignments
- Set `temperature=0` for deterministic code generation across all providers
- Tutoring path (`entrypoint.py`) defaults are unchanged — this only affects prompt-only assignment code generation

## Provider-specific handling
- **Gemini**: adds `generationConfig.maxOutputTokens` + `generationConfig.temperature` (Gemini uses different key names)
- **OpenAI-compatible** (Grok, Claude, NVIDIA NIM, Perplexity): overrides top-level `max_tokens` + `temperature`

## Test plan
- [x] 20 new tests in `tests/test_prompt_pipeline.py` covering all 5 providers
- [x] Verifies patched configs get codegen values
- [x] Verifies unpatched configs retain tutoring defaults
- [x] Verifies patching one instance does not affect other instances
- [x] Full suite: 231 passed (211 existing + 20 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)