### PR TITLE
refactor: extract shared LLM utilities to llm_utils.py

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,6 +3,7 @@
 !entrypoint.py
 !llm_client.py
 !llm_configs.py
+!llm_utils.py
 !locale/*.json
 !prompt.py
 !requirements.txt

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -151,4 +151,59 @@ jobs:
         echo "feedback_${{ matrix.model }}=${{ steps.integration.outputs.feedback }}" >> $GITHUB_OUTPUT
         python3 -u -m pytest tests/integration.py
 
+  integration-tests-codegen:
+    needs: build
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - model: gemini-2.5-flash
+            secret: GOOGLE_API_KEY
+          - model: grok-code-fast
+            secret: XAI_API_KEY
+          - model: claude-sonnet-4-20250514
+            secret: CLAUDE_API_KEY
+          - model: google/gemma-2-9b-it
+            secret: NVIDIA_NIM_API_KEY
+          - model: sonar
+            secret: PERPLEXITY_API_KEY
+      fail-fast: false
+    steps:
+    - uses: actions/checkout@v6
+
+    - name: Install uv package manager
+      uses: astral-sh/setup-uv@v7
+      with:
+        version: "latest"
+        version-file: "pyproject.toml"
+        python-version: 3.11
+        enable-cache: true
+
+    - run: uv sync
+
+    - name: Generate exercise.py with ${{ matrix.model }}
+      env:
+        INPUT_PROMPT-FILE: tests/sample_prompt.txt
+        CONTAINER_OUTPUT: ${{ runner.temp }}/codegen_output
+        INPUT_CLAUDE_API_KEY: ${{ secrets.CLAUDE_API_KEY }}
+        INPUT_GEMINI-API-KEY: ${{ secrets.GOOGLE_API_KEY }}
+        INPUT_GROK-API-KEY: ${{ secrets.XAI_API_KEY }}
+        INPUT_NVIDIA-API-KEY: ${{ secrets.NVIDIA_NIM_API_KEY }}
+        INPUT_PERPLEXITY-API-KEY: ${{ secrets.PERPLEXITY_API_KEY }}
+        INPUT_MODEL: ${{ matrix.model }}
+      run: |
+        . .venv/bin/activate
+        python3 prompt_pipeline/entrypoint.py
+      timeout-minutes: 5
+
+    - name: Show generated exercise.py
+      run: cat ${{ runner.temp }}/codegen_output/exercise.py
+
+    - name: Verify generated code
+      env:
+        CONTAINER_OUTPUT: ${{ runner.temp }}/codegen_output
+      run: |
+        . .venv/bin/activate
+        python3 -u -m pytest tests/integration_codegen.py -v
+
 # end .github/workflows/build.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ COPY requirements.txt /requirements.txt
 COPY prompt.py /prompt.py
 COPY llm_client.py /llm_client.py
 COPY llm_configs.py /llm_configs.py
+COPY llm_utils.py /llm_utils.py
 COPY locale/ /locale/
 
 RUN python3 -m pip install --upgrade pip

--- a/entrypoint.py
+++ b/entrypoint.py
@@ -17,7 +17,7 @@ sys.path.insert(
 
 
 from llm_client import LLMAPIClient
-from llm_configs import ClaudeConfig, GeminiConfig, GrokConfig, NvidiaNIMConfig, PerplexityConfig
+from llm_utils import get_config_class, get_model_key_from_env
 
 import prompt
 
@@ -142,127 +142,6 @@ def write_token_usage(
         logging.info(f"Token usage written to {usage_path}: {usage}")
     except OSError as e:
         logging.warning(f"Could not write token usage: {e}")
-
-
-def get_startwith(key:str, dictionary:dict) -> Any:
-    result = None
-    for k, v in dictionary.items():
-        if key.startswith(k):
-            result = v
-            break
-    return result
-
-
-def get_model_key_from_env() -> Tuple[str, str]:
-    """
-    Extracts the LLM model and API key from environment variables with flexible selection.
-    - Uses INPUT_API-KEY if provided, especially with a specified model.
-    - Falls back to model-specific API keys if INPUT_API-KEY is not set.
-    - Raises ValueError if no API keys are available.
-    - Uses model-to-provider mapping for precise model IDs.
-    """
-    api_key_dict = get_api_key_dict_from_env()
-    valid_keys_dict = {k: v for k, v in api_key_dict.items() if v and v.strip()}
-
-    model = os.getenv('INPUT_MODEL', '').lower()
-    general_api_key = os.getenv('INPUT_API-KEY', '').strip()
-
-    # Model-to-provider mapping for precise model IDs
-    model_to_provider = {
-        'google/gemma-2-9b-it': 'nvidia_nim',
-        'sonar': 'perplexity',
-        'gemini-2.5-flash': 'gemini',
-        'grok-code-fast': 'grok',
-        'claude-sonnet-4-20250514': 'claude'
-    }
-
-    # Case 1: Use INPUT_API-KEY if provided
-    if general_api_key:
-        selected_model = model or 'gemini-2.5-flash'  # Default to specific Gemini model
-        logging.info(f"Using INPUT_API-KEY for model: {selected_model}")
-        return selected_model, general_api_key
-
-    # Case 2: No INPUT_API-KEY, check model-specific keys
-    if not valid_keys_dict:
-        raise ValueError(
-            "No API keys provided. Set at least one of:\n"
-            "\tINPUT_API-KEY\n"
-            "\tINPUT_CLAUDE_API_KEY\n"
-            "\tINPUT_GEMINI-API-KEY\n"
-            "\tINPUT_GROK-API-KEY\n"
-            "\tINPUT_NVIDIA-API-KEY\n"
-            "\tINPUT_PERPLEXITY-API-KEY\n"
-        )
-
-    # Case 3: Only one API key available
-    if len(valid_keys_dict) == 1:
-        selected_model, api_key = next(iter(valid_keys_dict.items()))
-        logging.info(f"Using single available model: {selected_model}")
-        return selected_model, api_key.strip()
-
-    # Case 4: Use model-to-provider mapping for specified model
-    provider = model_to_provider.get(model, None)
-    if model and provider and provider in valid_keys_dict:
-        logging.info(f"Using mapped model: {model} with provider: {provider}")
-        return model, valid_keys_dict[provider].strip()
-
-    # Case 5: Fallback to provider-based matching
-    if model:
-        api_key = get_startwith(model, valid_keys_dict)
-        if api_key:
-            logging.info(f"Using specified model with provider matching: {model}")
-            return model, api_key.strip()
-
-    # Case 6: Fallback to Gemini if available
-    if 'gemini' in valid_keys_dict:
-        logging.info("Falling back to Gemini model")
-        return 'gemini-2.5-flash', valid_keys_dict['gemini'].strip()
-
-    # Case 7: No matching model or Gemini
-    raise ValueError(
-        f"No API key provided for specified model '{model}' and Gemini not available. "
-        f"Available models: {', '.join(valid_keys_dict.keys())}"
-    )
-
-
-def get_api_key_dict_from_env() -> Dict[str, str]:
-    """
-    Retrieves API keys for different models from environment variables.
-    Returns empty strings for unset variables.
-    """
-    return {
-        'claude': os.getenv('INPUT_CLAUDE_API_KEY', ''),
-        'gemini': os.getenv('INPUT_GEMINI-API-KEY', ''),
-        'grok': os.getenv('INPUT_GROK-API-KEY', ''),
-        'nvidia_nim': os.getenv('INPUT_NVIDIA-API-KEY', ''),
-        'perplexity': os.getenv('INPUT_PERPLEXITY-API-KEY', ''),
-    }
-
-
-def get_config_class_dict() -> Dict[str, type]:
-    """
-    Returns a dictionary mapping model names to their respective configuration classes.
-    """
-    return {
-        'claude': ClaudeConfig,
-        'claude-sonnet-4-20250514': ClaudeConfig,  # Add specific model
-        'gemini': GeminiConfig,
-        'gemini-2.5-flash': GeminiConfig,
-        'grok': GrokConfig,
-        'grok-code-fast': GrokConfig,
-        'nvidia_nim': NvidiaNIMConfig,
-        'google/gemma-2-9b-it': NvidiaNIMConfig,  # Add specific model
-        'perplexity': PerplexityConfig,
-        'sonar': PerplexityConfig  # Add specific model
-    }
-
-
-def get_config_class(model: str) -> type:
-    config_map = get_config_class_dict()
-    config_class = get_startwith(model, config_map)
-    if not config_class:
-        raise ValueError(f"Unsupported LLM type: {model}. Use {', '.join(config_map.keys())}")
-    return config_class
 
 
 def get_path_tuple(paths_str: str) -> Tuple[pathlib.Path]:

--- a/llm_utils.py
+++ b/llm_utils.py
@@ -1,0 +1,145 @@
+# begin llm_utils.py
+"""Shared LLM utilities used by both the tutor and prompt pipeline.
+
+Extracted from entrypoint.py to eliminate circular imports between
+entrypoint.py and prompt_pipeline/entrypoint.py.
+"""
+
+import logging
+import os
+
+from typing import Any, Dict, Tuple
+
+from llm_configs import (
+    ClaudeConfig,
+    GeminiConfig,
+    GrokConfig,
+    NvidiaNIMConfig,
+    PerplexityConfig,
+)
+
+
+logging.basicConfig(level=logging.INFO)
+
+
+def get_startwith(key: str, dictionary: dict) -> Any:
+    result = None
+    for k, v in dictionary.items():
+        if key.startswith(k):
+            result = v
+            break
+    return result
+
+
+def get_api_key_dict_from_env() -> Dict[str, str]:
+    """
+    Retrieves API keys for different models from environment variables.
+    Returns empty strings for unset variables.
+    """
+    return {
+        'claude': os.getenv('INPUT_CLAUDE_API_KEY', ''),
+        'gemini': os.getenv('INPUT_GEMINI-API-KEY', ''),
+        'grok': os.getenv('INPUT_GROK-API-KEY', ''),
+        'nvidia_nim': os.getenv('INPUT_NVIDIA-API-KEY', ''),
+        'perplexity': os.getenv('INPUT_PERPLEXITY-API-KEY', ''),
+    }
+
+
+def get_config_class_dict() -> Dict[str, type]:
+    """
+    Returns a dictionary mapping model names to their respective configuration classes.
+    """
+    return {
+        'claude': ClaudeConfig,
+        'claude-sonnet-4-20250514': ClaudeConfig,  # Add specific model
+        'gemini': GeminiConfig,
+        'gemini-2.5-flash': GeminiConfig,
+        'grok': GrokConfig,
+        'grok-code-fast': GrokConfig,
+        'nvidia_nim': NvidiaNIMConfig,
+        'google/gemma-2-9b-it': NvidiaNIMConfig,  # Add specific model
+        'perplexity': PerplexityConfig,
+        'sonar': PerplexityConfig  # Add specific model
+    }
+
+
+def get_config_class(model: str) -> type:
+    config_map = get_config_class_dict()
+    config_class = get_startwith(model, config_map)
+    if not config_class:
+        raise ValueError(f"Unsupported LLM type: {model}. Use {', '.join(config_map.keys())}")
+    return config_class
+
+
+def get_model_key_from_env() -> Tuple[str, str]:
+    """
+    Extracts the LLM model and API key from environment variables with flexible selection.
+    - Uses INPUT_API-KEY if provided, especially with a specified model.
+    - Falls back to model-specific API keys if INPUT_API-KEY is not set.
+    - Raises ValueError if no API keys are available.
+    - Uses model-to-provider mapping for precise model IDs.
+    """
+    api_key_dict = get_api_key_dict_from_env()
+    valid_keys_dict = {k: v for k, v in api_key_dict.items() if v and v.strip()}
+
+    model = os.getenv('INPUT_MODEL', '').lower()
+    general_api_key = os.getenv('INPUT_API-KEY', '').strip()
+
+    # Model-to-provider mapping for precise model IDs
+    model_to_provider = {
+        'google/gemma-2-9b-it': 'nvidia_nim',
+        'sonar': 'perplexity',
+        'gemini-2.5-flash': 'gemini',
+        'grok-code-fast': 'grok',
+        'claude-sonnet-4-20250514': 'claude'
+    }
+
+    # Case 1: Use INPUT_API-KEY if provided
+    if general_api_key:
+        selected_model = model or 'gemini-2.5-flash'  # Default to specific Gemini model
+        logging.info(f"Using INPUT_API-KEY for model: {selected_model}")
+        return selected_model, general_api_key
+
+    # Case 2: No INPUT_API-KEY, check model-specific keys
+    if not valid_keys_dict:
+        raise ValueError(
+            "No API keys provided. Set at least one of:\n"
+            "\tINPUT_API-KEY\n"
+            "\tINPUT_CLAUDE_API_KEY\n"
+            "\tINPUT_GEMINI-API-KEY\n"
+            "\tINPUT_GROK-API-KEY\n"
+            "\tINPUT_NVIDIA-API-KEY\n"
+            "\tINPUT_PERPLEXITY-API-KEY\n"
+        )
+
+    # Case 3: Only one API key available
+    if len(valid_keys_dict) == 1:
+        selected_model, api_key = next(iter(valid_keys_dict.items()))
+        logging.info(f"Using single available model: {selected_model}")
+        return selected_model, api_key.strip()
+
+    # Case 4: Use model-to-provider mapping for specified model
+    provider = model_to_provider.get(model, None)
+    if model and provider and provider in valid_keys_dict:
+        logging.info(f"Using mapped model: {model} with provider: {provider}")
+        return model, valid_keys_dict[provider].strip()
+
+    # Case 5: Fallback to provider-based matching
+    if model:
+        api_key = get_startwith(model, valid_keys_dict)
+        if api_key:
+            logging.info(f"Using specified model with provider matching: {model}")
+            return model, api_key.strip()
+
+    # Case 6: Fallback to Gemini if available
+    if 'gemini' in valid_keys_dict:
+        logging.info("Falling back to Gemini model")
+        return 'gemini-2.5-flash', valid_keys_dict['gemini'].strip()
+
+    # Case 7: No matching model or Gemini
+    raise ValueError(
+        f"No API key provided for specified model '{model}' and Gemini not available. "
+        f"Available models: {', '.join(valid_keys_dict.keys())}"
+    )
+
+# end llm_utils.py

--- a/prompt_pipeline/entrypoint.py
+++ b/prompt_pipeline/entrypoint.py
@@ -26,7 +26,41 @@ _ai_tutor = pathlib.Path(__file__).parent.parent / 'ai_tutor'
 sys.path.insert(0, str(_ai_tutor))
 
 from llm_client import LLMAPIClient  # noqa: E402
+from llm_configs import GeminiConfig, LLMConfig  # noqa: E402
 from entrypoint import get_model_key_from_env, get_config_class  # noqa: E402
+
+
+# Code generation needs higher token limits and deterministic output.
+# Tutoring (entrypoint.py) uses the config defaults (96 tokens, temp 0.2).
+CODEGEN_MAX_TOKENS = 4096
+CODEGEN_TEMPERATURE = 0
+
+
+def patch_config_for_codegen(config: LLMConfig) -> None:
+    """Override generation parameters for code generation.
+
+    Wraps config.format_request_data to set higher max_tokens and
+    temperature=0. Gemini uses ``generationConfig``; OpenAI-compatible
+    providers use top-level ``max_tokens`` / ``temperature``.
+    """
+    original = config.format_request_data
+
+    if isinstance(config, GeminiConfig):
+        def patched(question: str):
+            data = original(question)
+            data['generationConfig'] = {
+                'maxOutputTokens': CODEGEN_MAX_TOKENS,
+                'temperature': CODEGEN_TEMPERATURE,
+            }
+            return data
+    else:
+        def patched(question: str):
+            data = original(question)
+            data['max_tokens'] = CODEGEN_MAX_TOKENS
+            data['temperature'] = CODEGEN_TEMPERATURE
+            return data
+
+    config.format_request_data = patched
 
 
 # Python code detection patterns — prompts containing these are rejected.
@@ -99,6 +133,7 @@ def main() -> None:
     if model:
         config_args['model'] = model
     config = config_class(**config_args)
+    patch_config_for_codegen(config)
     client = LLMAPIClient(config)
 
     question = build_question(student_prompt)

--- a/prompt_pipeline/entrypoint.py
+++ b/prompt_pipeline/entrypoint.py
@@ -20,14 +20,19 @@ import sys
 logging.basicConfig(level=logging.INFO)
 
 # ai_tutor/ lives one level above prompt_pipeline/ inside the container:
-#   /app/ai_tutor/   ← llm_client.py, llm_configs.py, entrypoint.py
+#   /app/ai_tutor/   ← llm_client.py, llm_configs.py, llm_utils.py
 #   /app/prompt_pipeline/  ← this file
-_ai_tutor = pathlib.Path(__file__).parent.parent / 'ai_tutor'
-sys.path.insert(0, str(_ai_tutor))
+# In CI / local dev, the modules live at the repo root instead.
+_project_root = pathlib.Path(__file__).parent.parent
+_ai_tutor = _project_root / 'ai_tutor'
+if _ai_tutor.is_dir():
+    sys.path.insert(0, str(_ai_tutor))
+else:
+    sys.path.insert(0, str(_project_root))
 
 from llm_client import LLMAPIClient  # noqa: E402
 from llm_configs import GeminiConfig, LLMConfig  # noqa: E402
-from entrypoint import get_model_key_from_env, get_config_class  # noqa: E402
+from llm_utils import get_model_key_from_env, get_config_class  # noqa: E402
 
 
 # Code generation needs higher token limits and deterministic output.

--- a/tests/integration_codegen.py
+++ b/tests/integration_codegen.py
@@ -1,0 +1,93 @@
+# begin tests/integration_codegen.py
+"""Integration tests for the prompt pipeline (code generation).
+
+Run after prompt_pipeline/entrypoint.py has generated exercise.py.
+Verifies the output is valid Python containing the expected functions.
+"""
+import ast
+import logging
+import os
+import pathlib
+
+import pytest
+
+
+logging.basicConfig(level=logging.INFO)
+
+
+@pytest.fixture
+def exercise_path():
+    """Path to the generated exercise.py."""
+    output_dir = os.environ.get('CONTAINER_OUTPUT', '')
+    if not output_dir:
+        pytest.skip("CONTAINER_OUTPUT not set")
+    path = pathlib.Path(output_dir) / 'exercise.py'
+    if not path.exists():
+        pytest.fail(f"exercise.py not found at {path}")
+    return path
+
+
+@pytest.fixture
+def exercise_source(exercise_path):
+    """Raw source code of generated exercise.py."""
+    return exercise_path.read_text(encoding='utf-8')
+
+
+@pytest.fixture
+def exercise_ast(exercise_source):
+    """Parsed AST of generated exercise.py."""
+    try:
+        return ast.parse(exercise_source)
+    except SyntaxError as e:
+        pytest.fail(f"exercise.py has invalid syntax: {e}")
+
+
+def test_exercise_exists(exercise_path):
+    """exercise.py was written to disk."""
+    assert exercise_path.exists()
+
+
+def test_exercise_not_empty(exercise_source):
+    """exercise.py is not empty."""
+    assert len(exercise_source.strip()) > 0
+
+
+def test_exercise_valid_python(exercise_ast):
+    """exercise.py parses as valid Python."""
+    assert exercise_ast is not None
+
+
+def test_exercise_has_add_function(exercise_ast):
+    """exercise.py defines an `add` function."""
+    func_names = [
+        node.name for node in ast.walk(exercise_ast)
+        if isinstance(node, ast.FunctionDef)
+    ]
+    assert 'add' in func_names, (
+        f"Expected 'add' function, found: {func_names}"
+    )
+
+
+def test_exercise_has_multiply_function(exercise_ast):
+    """exercise.py defines a `multiply` function."""
+    func_names = [
+        node.name for node in ast.walk(exercise_ast)
+        if isinstance(node, ast.FunctionDef)
+    ]
+    assert 'multiply' in func_names, (
+        f"Expected 'multiply' function, found: {func_names}"
+    )
+
+
+def test_exercise_not_truncated(exercise_source):
+    """exercise.py is long enough to contain two function definitions."""
+    assert len(exercise_source) > 50, (
+        f"exercise.py suspiciously short ({len(exercise_source)} chars) "
+        "— may have been truncated by low max_tokens"
+    )
+
+
+if __name__ == "__main__":
+    pytest.main(["--verbose", __file__])
+
+# end tests/integration_codegen.py

--- a/tests/sample_prompt.txt
+++ b/tests/sample_prompt.txt
@@ -1,0 +1,2 @@
+Write a Python function called `add(a, b)` that takes two numbers as parameters and returns their sum.
+Also write a function called `multiply(a, b)` that takes two numbers and returns their product.

--- a/tests/test_entrypoint.py
+++ b/tests/test_entrypoint.py
@@ -16,6 +16,7 @@ sys.path.insert(
 
 import entrypoint
 import llm_configs
+import llm_utils
 
 PATH_TUPLE = Tuple[pathlib.Path]
 PATH_TUPLE_STR = Tuple[PATH_TUPLE, str]
@@ -82,7 +83,7 @@ def test_get_model_key_from_env__valid_specified(monkeypatch, model, env_key, ex
     monkeypatch.setenv("INPUT_GEMINI-API-KEY", "gemini_key")
     monkeypatch.setenv(env_key, expected_key)
     monkeypatch.setenv("INPUT_MODEL", model)
-    result_model, result_key = entrypoint.get_model_key_from_env()
+    result_model, result_key = llm_utils.get_model_key_from_env()
     assert result_model == model
     assert result_key == expected_key
 
@@ -91,7 +92,7 @@ def test_get_model_key_from_env__valid_specified(monkeypatch, model, env_key, ex
 def test_get_model_key_from_env__single_key(monkeypatch, model, env_key, expected_key):
     """Test with only one key available (uses it regardless of INPUT_MODEL)."""
     monkeypatch.setenv(env_key, expected_key)
-    result_model, result_key = entrypoint.get_model_key_from_env()
+    result_model, result_key = llm_utils.get_model_key_from_env()
     assert result_model == model
     assert result_key == expected_key
 
@@ -99,7 +100,7 @@ def test_get_model_key_from_env__single_key(monkeypatch, model, env_key, expecte
 def test_get_model_key_from_env__no_keys(monkeypatch):
     """Test with no API keys available."""
     with pytest.raises(ValueError, match="No API keys provided. Set at least one of"):
-        entrypoint.get_model_key_from_env()
+        llm_utils.get_model_key_from_env()
 
 
 def test_get_model_key_from_env__fallback_gemini(monkeypatch):
@@ -107,7 +108,7 @@ def test_get_model_key_from_env__fallback_gemini(monkeypatch):
     monkeypatch.setenv("INPUT_MODEL", "invalid")
     monkeypatch.setenv("INPUT_GEMINI-API-KEY", "gemini_key")
     monkeypatch.setenv("INPUT_GROK-API-KEY", "grok_key")  # Multiple, but fallback to Gemini
-    result_model, result_key = entrypoint.get_model_key_from_env()
+    result_model, result_key = llm_utils.get_model_key_from_env()
     assert result_model == "gemini-2.5-flash"
     assert result_key == "gemini_key"
 
@@ -116,7 +117,7 @@ def test_get_model_key_from_env__no_model_fallback_gemini(monkeypatch):
     """Test no INPUT_MODEL set, fallback to Gemini if available."""
     monkeypatch.setenv("INPUT_CLAUDE_API_KEY", "claude_key")
     monkeypatch.setenv("INPUT_GEMINI-API-KEY", "gemini_key")
-    result_model, result_key = entrypoint.get_model_key_from_env()
+    result_model, result_key = llm_utils.get_model_key_from_env()
     assert result_model == "gemini-2.5-flash"
     assert result_key == "gemini_key"
 
@@ -125,7 +126,7 @@ def test_get_model_key_from_env__invalid_model_no_gemini(monkeypatch):
     """Test invalid specified model, no Gemini available."""
     monkeypatch.setenv("INPUT_MODEL", "invalid")
     monkeypatch.setenv("INPUT_CLAUDE_API_KEY", "claude_key")
-    result_model, result_key = entrypoint.get_model_key_from_env()
+    result_model, result_key = llm_utils.get_model_key_from_env()
     assert result_key == "claude_key"
     assert result_model == "claude"
 
@@ -134,7 +135,7 @@ def test_get_model_key_from_env__empty_key_ignored(monkeypatch):
     """Test empty/whitespace keys are ignored (treated as unavailable)."""
     monkeypatch.setenv("INPUT_CLAUDE_API_KEY", "   ")  # Empty after strip
     monkeypatch.setenv("INPUT_GEMINI-API-KEY", "gemini_key")
-    result_model, result_key = entrypoint.get_model_key_from_env()
+    result_model, result_key = llm_utils.get_model_key_from_env()
     assert result_model == "gemini"
     assert result_key == "gemini_key"
 
@@ -148,20 +149,20 @@ def test_get_model_key_from_env__empty_key_ignored(monkeypatch):
 ])
 def test_get_config_class(model, expected_class):
     """Test get_config_class returns correct configuration class."""
-    assert entrypoint.get_config_class(model) == expected_class
+    assert llm_utils.get_config_class(model) == expected_class
 
 
 def test_get_config_class_invalid_model():
     """Test get_config_class with invalid model."""
     with pytest.raises(ValueError, match="Unsupported LLM type: invalid_model"):
-        entrypoint.get_config_class("invalid_model")
+        llm_utils.get_config_class("invalid_model")
 
 
 def test_get_model_key_from_env_with_api_key(monkeypatch):
     """Test that INPUT_API-KEY is used when provided with a model."""
     monkeypatch.setenv("INPUT_API-KEY", "test-api-key")
     monkeypatch.setenv("INPUT_MODEL", "gemini")
-    model, api_key = entrypoint.get_model_key_from_env()
+    model, api_key = llm_utils.get_model_key_from_env()
     assert model == "gemini"
     assert api_key == "test-api-key"
 

--- a/tests/test_prompt_pipeline.py
+++ b/tests/test_prompt_pipeline.py
@@ -1,0 +1,202 @@
+# begin tests/test_prompt_pipeline.py
+"""Tests for prompt_pipeline code-generation config overrides."""
+import pathlib
+import sys
+
+import pytest
+
+
+# Adjust sys.path to import from project root
+test_folder = pathlib.Path(__file__).parent.resolve()
+project_folder = test_folder.parent.resolve()
+sys.path.insert(0, str(project_folder))
+
+from llm_configs import (
+    ClaudeConfig, GeminiConfig, GrokConfig, NvidiaNIMConfig, PerplexityConfig,
+)
+
+# prompt_pipeline.entrypoint imports from the tutor entrypoint via sys.path
+# manipulation that only works inside Docker.  Import the constants and
+# function we need by loading the file directly with importlib.
+import importlib.util
+
+_pp_spec = importlib.util.spec_from_file_location(
+    "prompt_pipeline_entrypoint",
+    project_folder / "prompt_pipeline" / "entrypoint.py",
+    submodule_search_locations=[],
+)
+_pp_mod = importlib.util.module_from_spec(_pp_spec)
+
+# Satisfy the "from entrypoint import ..." that prompt_pipeline/entrypoint.py
+# does at import time — point it at the tutor's entrypoint module.
+sys.modules['entrypoint'] = importlib.import_module('entrypoint')
+_pp_spec.loader.exec_module(_pp_mod)
+
+CODEGEN_MAX_TOKENS = _pp_mod.CODEGEN_MAX_TOKENS
+CODEGEN_TEMPERATURE = _pp_mod.CODEGEN_TEMPERATURE
+patch_config_for_codegen = _pp_mod.patch_config_for_codegen
+
+
+SAMPLE_API_KEY = "test_api_key_for_codegen"
+SAMPLE_QUESTION = "Write a function that computes factorial."
+
+
+# --- patch_config_for_codegen tests ---
+
+
+class TestPatchGemini:
+    """Gemini uses generationConfig with different key names."""
+
+    @pytest.fixture
+    def config(self):
+        c = GeminiConfig(api_key=SAMPLE_API_KEY)
+        patch_config_for_codegen(c)
+        return c
+
+    def test_has_generation_config(self, config):
+        data = config.format_request_data(SAMPLE_QUESTION)
+        assert 'generationConfig' in data
+
+    def test_max_output_tokens(self, config):
+        data = config.format_request_data(SAMPLE_QUESTION)
+        assert data['generationConfig']['maxOutputTokens'] == CODEGEN_MAX_TOKENS
+
+    def test_temperature_zero(self, config):
+        data = config.format_request_data(SAMPLE_QUESTION)
+        assert data['generationConfig']['temperature'] == CODEGEN_TEMPERATURE
+
+    def test_contents_preserved(self, config):
+        data = config.format_request_data(SAMPLE_QUESTION)
+        assert 'contents' in data
+        assert data['contents'][0]['parts'][0]['text'] == SAMPLE_QUESTION
+
+
+class TestPatchGrok:
+    """Grok already sets temperature=0; patch should override max_tokens."""
+
+    @pytest.fixture
+    def config(self):
+        c = GrokConfig(api_key=SAMPLE_API_KEY)
+        patch_config_for_codegen(c)
+        return c
+
+    def test_max_tokens(self, config):
+        data = config.format_request_data(SAMPLE_QUESTION)
+        assert data['max_tokens'] == CODEGEN_MAX_TOKENS
+
+    def test_temperature_zero(self, config):
+        data = config.format_request_data(SAMPLE_QUESTION)
+        assert data['temperature'] == CODEGEN_TEMPERATURE
+
+    def test_model_preserved(self, config):
+        data = config.format_request_data(SAMPLE_QUESTION)
+        assert data['model'] == 'grok-code-fast'
+
+
+class TestPatchNvidiaNIM:
+    """NVIDIA NIM inherits base defaults (96 tokens, temp 0.2)."""
+
+    @pytest.fixture
+    def config(self):
+        c = NvidiaNIMConfig(api_key=SAMPLE_API_KEY)
+        patch_config_for_codegen(c)
+        return c
+
+    def test_max_tokens_overridden(self, config):
+        data = config.format_request_data(SAMPLE_QUESTION)
+        assert data['max_tokens'] == CODEGEN_MAX_TOKENS
+
+    def test_temperature_overridden(self, config):
+        data = config.format_request_data(SAMPLE_QUESTION)
+        assert data['temperature'] == CODEGEN_TEMPERATURE
+
+
+class TestPatchClaude:
+    """Claude overrides max_tokens to 1024; patch should raise to CODEGEN_MAX_TOKENS."""
+
+    @pytest.fixture
+    def config(self):
+        c = ClaudeConfig(api_key=SAMPLE_API_KEY)
+        patch_config_for_codegen(c)
+        return c
+
+    def test_max_tokens_overridden(self, config):
+        data = config.format_request_data(SAMPLE_QUESTION)
+        assert data['max_tokens'] == CODEGEN_MAX_TOKENS
+
+    def test_temperature_overridden(self, config):
+        data = config.format_request_data(SAMPLE_QUESTION)
+        assert data['temperature'] == CODEGEN_TEMPERATURE
+
+
+class TestPatchPerplexity:
+    """Perplexity overrides max_tokens to 384; patch should raise to CODEGEN_MAX_TOKENS."""
+
+    @pytest.fixture
+    def config(self):
+        c = PerplexityConfig(api_key=SAMPLE_API_KEY)
+        patch_config_for_codegen(c)
+        return c
+
+    def test_max_tokens_overridden(self, config):
+        data = config.format_request_data(SAMPLE_QUESTION)
+        assert data['max_tokens'] == CODEGEN_MAX_TOKENS
+
+    def test_temperature_overridden(self, config):
+        data = config.format_request_data(SAMPLE_QUESTION)
+        assert data['temperature'] == CODEGEN_TEMPERATURE
+
+
+class TestUnpatchedDefaults:
+    """Verify that unpatched configs retain their original defaults."""
+
+    def test_base_max_tokens_96(self):
+        c = NvidiaNIMConfig(api_key=SAMPLE_API_KEY)
+        data = c.format_request_data(SAMPLE_QUESTION)
+        assert data['max_tokens'] == 96
+
+    def test_base_temperature_02(self):
+        c = NvidiaNIMConfig(api_key=SAMPLE_API_KEY)
+        data = c.format_request_data(SAMPLE_QUESTION)
+        assert data['temperature'] == 0.2
+
+    def test_gemini_no_generation_config(self):
+        c = GeminiConfig(api_key=SAMPLE_API_KEY)
+        data = c.format_request_data(SAMPLE_QUESTION)
+        assert 'generationConfig' not in data
+
+    def test_claude_max_tokens_1024(self):
+        c = ClaudeConfig(api_key=SAMPLE_API_KEY)
+        data = c.format_request_data(SAMPLE_QUESTION)
+        assert data['max_tokens'] == 1024
+
+    def test_perplexity_max_tokens_384(self):
+        c = PerplexityConfig(api_key=SAMPLE_API_KEY)
+        data = c.format_request_data(SAMPLE_QUESTION)
+        assert data['max_tokens'] == 384
+
+
+class TestPatchDoesNotMutateOtherInstances:
+    """Patching one config must not affect a separate instance."""
+
+    def test_two_gemini_instances(self):
+        patched = GeminiConfig(api_key=SAMPLE_API_KEY)
+        unpatched = GeminiConfig(api_key=SAMPLE_API_KEY)
+        patch_config_for_codegen(patched)
+
+        assert 'generationConfig' in patched.format_request_data(SAMPLE_QUESTION)
+        assert 'generationConfig' not in unpatched.format_request_data(SAMPLE_QUESTION)
+
+    def test_two_grok_instances(self):
+        patched = GrokConfig(api_key=SAMPLE_API_KEY)
+        unpatched = GrokConfig(api_key=SAMPLE_API_KEY)
+        patch_config_for_codegen(patched)
+
+        assert patched.format_request_data(SAMPLE_QUESTION)['max_tokens'] == CODEGEN_MAX_TOKENS
+        assert 'max_tokens' not in unpatched.format_request_data(SAMPLE_QUESTION)
+
+
+if __name__ == "__main__":
+    pytest.main(["--verbose", __file__])
+
+# end tests/test_prompt_pipeline.py

--- a/tests/test_prompt_pipeline.py
+++ b/tests/test_prompt_pipeline.py
@@ -10,31 +10,19 @@ import pytest
 test_folder = pathlib.Path(__file__).parent.resolve()
 project_folder = test_folder.parent.resolve()
 sys.path.insert(0, str(project_folder))
+sys.path.insert(0, str(project_folder / "prompt_pipeline"))
 
 from llm_configs import (
     ClaudeConfig, GeminiConfig, GrokConfig, NvidiaNIMConfig, PerplexityConfig,
 )
 
-# prompt_pipeline.entrypoint imports from the tutor entrypoint via sys.path
-# manipulation that only works inside Docker.  Import the constants and
-# function we need by loading the file directly with importlib.
-import importlib.util
+# Now that prompt_pipeline/entrypoint.py imports from llm_utils (not
+# the tutor entrypoint), we can import it as a normal module.
+import prompt_pipeline.entrypoint as pp_entrypoint
 
-_pp_spec = importlib.util.spec_from_file_location(
-    "prompt_pipeline_entrypoint",
-    project_folder / "prompt_pipeline" / "entrypoint.py",
-    submodule_search_locations=[],
-)
-_pp_mod = importlib.util.module_from_spec(_pp_spec)
-
-# Satisfy the "from entrypoint import ..." that prompt_pipeline/entrypoint.py
-# does at import time — point it at the tutor's entrypoint module.
-sys.modules['entrypoint'] = importlib.import_module('entrypoint')
-_pp_spec.loader.exec_module(_pp_mod)
-
-CODEGEN_MAX_TOKENS = _pp_mod.CODEGEN_MAX_TOKENS
-CODEGEN_TEMPERATURE = _pp_mod.CODEGEN_TEMPERATURE
-patch_config_for_codegen = _pp_mod.patch_config_for_codegen
+CODEGEN_MAX_TOKENS = pp_entrypoint.CODEGEN_MAX_TOKENS
+CODEGEN_TEMPERATURE = pp_entrypoint.CODEGEN_TEMPERATURE
+patch_config_for_codegen = pp_entrypoint.patch_config_for_codegen
 
 
 SAMPLE_API_KEY = "test_api_key_for_codegen"


### PR DESCRIPTION
## Summary
- Extract `get_startwith`, `get_model_key_from_env`, `get_api_key_dict_from_env`, `get_config_class_dict`, `get_config_class` from `entrypoint.py` into new `llm_utils.py`
- Eliminate circular import between `entrypoint.py` and `prompt_pipeline/entrypoint.py` — both now import from `llm_utils`
- Fix `prompt_pipeline/entrypoint.py` sys.path resolution: falls back to repo root when Docker-only `ai_tutor/` is absent (fixes `ModuleNotFoundError` in CI)
- Simplify `test_prompt_pipeline.py` imports (remove `importlib.util` workaround)

## Motivation
PR #34 revealed that the circular import architecture (prompt_pipeline importing from tutor entrypoint via sys.path hacks) breaks outside Docker. This refactor provides a clean foundation for future prompt pipeline features.

## Test plan
- [x] All 231 existing tests pass locally
- [x] CI unit tests pass (upstream `build.yml`)
- [x] Integration tests pass via `cpf2503-20tue78/ai-tutor-ci` harness

Supersedes #35 (branch renamed to match `feature/**` trigger pattern).

🤖 Generated with [Claude Code](https://claude.com/claude-code)